### PR TITLE
Fixed meneScene Change at death

### DIFF
--- a/static/Character.js
+++ b/static/Character.js
@@ -430,7 +430,6 @@ class Character {
             }
             this.myContainer.destroy();
             this.client.socket.emit("hadDied");
-            this.context.scene.start('menuScene');
         }
         
     }

--- a/static/SocketFunc.js
+++ b/static/SocketFunc.js
@@ -46,9 +46,10 @@ class SocketFunc {
                         
                         self.otherPlayers[id].initSprite(self);
                         self.otherPlayers[id].updateHealth();
-                        self.otherPlayers[id].myContainer.data = {my_id: id};
                         
-                                            
+                        self.otherPlayers[id].myContainer.setDataEnabled();
+                        self.otherPlayers[id].myContainer.data.set("my_id", id);
+                        
                         self.otherPlayersGroup.add(self.otherPlayers[id].myContainer);
                         
                         self.physics.add.collider(self.otherPlayers[id].myContainer, self.collidableLayer);

--- a/static/gameScene.js
+++ b/static/gameScene.js
@@ -209,7 +209,7 @@ class gameScene extends Phaser.Scene {
         
         // Update the movement of all the other players
         // To update add .sprite to the end of otherPlayers[object.id]
-        this.client.socket.on('moveUpdates', function(object){ 
+        this.client.socket.on('moveUpdates', function(object){
             self.socketFunc.moveUpdates(self, object);
         });
         
@@ -265,7 +265,9 @@ class gameScene extends Phaser.Scene {
         this.player.update(this);
         this.projectileHandler.moveProjectiles();
 
-    
+        if(this.player.health <= 0){
+            this.scene.start("menuScene", {});
+        }
 
     }  
     


### PR DESCRIPTION
Fixed bug involving the destroying of the data manager when switching scene. Had to use proper way of accessing the data field of gameObjects with setData().